### PR TITLE
fix bundle image label

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -93,7 +93,7 @@ jobs:
         if ! [[ ${last_commit_log} =~ .*skipbundle.* ]]; then
           echo "Publish bundle image"
           cd operator
-          make bundle
+          make bundle CHANNELS=alpha DEFAULT_CHANNEL=alpha
           make bundle-push
         else
           echo "Skip publish operator image"

--- a/operator/bundle.Dockerfile
+++ b/operator/bundle.Dockerfile
@@ -5,11 +5,13 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=dataset-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
+LABEL operators.operatorframework.io.bundle.channel.default.v1=alpha
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.4.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v2
 LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
+
 COPY bundle/manifests /manifests/
 COPY bundle/metadata /metadata/
 COPY bundle/tests/scorecard /tests/scorecard/

--- a/operator/bundle/metadata/annotations.yaml
+++ b/operator/bundle/metadata/annotations.yaml
@@ -1,4 +1,5 @@
 annotations:
+  operators.operatorframework.io.bundle.channel.default.v1: alpha
   operators.operatorframework.io.bundle.channels.v1: alpha
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1


### PR DESCRIPTION
### Issue Details
**Description**
Fix missing bundle image label

### Checklist

- [ ] E2E tests pass  - n/a
- [ ] Unit tests are included - n/a
- [ ] Driver version updated (if applicable) - n/a
- [ ] Operator version updated (if applicable) - n/a
- [ ] Operator bundle version updated (if applicable) - n/a
- [x] DCO sign-off included

[Developer Certificate of Origin (DCO)](https://developercertificate.org/) Sign off

Signed-off-by: grishgo-dev <79328212+grishgo-dev@users.noreply.github.com>

**Note** 
All commits to `main` will publish driver, operator and operator bundle container images. To skip one or more of these, use the following indicators in the PR commit title: `skipdriver`, `skipoperator`, `skipbundle`
