### PR TITLE
protect kube- and openshift- namespaces from auto mount

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -1,5 +1,5 @@
 # Current Operator version
-VERSION ?= 1.0.5
+VERSION ?= 1.0.6
 # Default bundle image tag
 BUNDLE_IMG ?= controller-bundle:$(VERSION)
 # Options for 'bundle-build'
@@ -18,7 +18,7 @@ OPERATOR_IMAGE_NAME = marketplace-dataset-operator
 OPERATOR_IMAGE_TAG ?= $(TAG)
 OPERATOR_IMAGE ?= $(IMAGE_REGISTRY)/$(OPERATOR_IMAGE_NAME):$(OPERATOR_IMAGE_TAG)
 
-BUNDLE_IMAGE_VERSION ?= 1.0.9
+BUNDLE_IMAGE_VERSION ?= 1.0.10
 BUNDLE_IMAGE_NAME = marketplace-dataset-operator-manifest
 BUNDLE_IMAGE ?= $(IMAGE_REGISTRY)/$(BUNDLE_IMAGE_NAME):$(BUNDLE_IMAGE_VERSION)
 

--- a/operator/bundle/manifests/dataset-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/dataset-operator.clusterserviceversion.yaml
@@ -45,10 +45,10 @@ metadata:
       ]
     capabilities: Full Lifecycle
     categories: Developer Tools
-    containerImage: quay.io/rh-marketplace/marketplace-dataset-operator:1.0.5
-    createdAt: "2021-05-14T17:02:02Z"
+    containerImage: quay.io/rh-marketplace/marketplace-dataset-operator:1.0.6
+    createdAt: "2021-05-18T14:50:02Z"
     description: The Red Hat Marketplace Dataset Operator provides a CSI driver to mount datasets purchased from Red Hat Marketplace into OpenShift workloads.
-    olm.skipRange: '>=0.0.0 <1.0.5'
+    olm.skipRange: '>=0.0.0 <1.0.6'
     operatorframework.io/suggested-namespace: openshift-operators
     operators.operatorframework.io/builder: operator-sdk-v1.4.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
@@ -60,7 +60,7 @@ metadata:
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
     razee/watch-resource: lite
-  name: dataset-operator.v1.0.5
+  name: dataset-operator.v1.0.6
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -379,7 +379,7 @@ spec:
                 env:
                 - name: POD_NAME
                   value: redhat-marketplace-dataset-operator
-                image: quay.io/rh-marketplace/marketplace-dataset-operator:1.0.5
+                image: quay.io/rh-marketplace/marketplace-dataset-operator:1.0.6
                 name: manager
                 ports:
                 - containerPort: 9443
@@ -467,7 +467,7 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat Marketplace
-  version: 1.0.5
+  version: 1.0.6
   webhookdefinitions:
   - admissionReviewVersions:
     - v1beta1

--- a/operator/config/manager/kustomization.yaml
+++ b/operator/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/rh-marketplace/marketplace-dataset-operator
-  newTag: 1.0.5
+  newTag: 1.0.6

--- a/operator/config/manifests/bases/dataset-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/dataset-operator.clusterserviceversion.yaml
@@ -5,10 +5,10 @@ metadata:
     alm-examples: '[]'
     capabilities: Full Lifecycle
     categories: Developer Tools
-    containerImage: quay.io/rh-marketplace/marketplace-dataset-operator:1.0.5
-    createdAt: "2021-05-14T17:02:02Z"
+    containerImage: quay.io/rh-marketplace/marketplace-dataset-operator:1.0.6
+    createdAt: "2021-05-18T14:50:02Z"
     description: The Red Hat Marketplace Dataset Operator provides a CSI driver to mount datasets purchased from Red Hat Marketplace into OpenShift workloads.
-    olm.skipRange: '>=0.0.0 <1.0.5'
+    olm.skipRange: '>=0.0.0 <1.0.6'
     operatorframework.io/suggested-namespace: openshift-operators
     repository: https://github.com/redhat-marketplace/marketplace-csi-driver
     support: IBM Corporation

--- a/operator/deploy/dev-operator.yaml
+++ b/operator/deploy/dev-operator.yaml
@@ -783,7 +783,7 @@ spec:
         env:
         - name: POD_NAME
           value: redhat-marketplace-dataset-operator
-        image: quay.io/rh-marketplace/marketplace-dataset-operator:1.0.5
+        image: quay.io/rh-marketplace/marketplace-dataset-operator:1.0.6
         name: manager
         ports:
         - containerPort: 9443

--- a/operator/pkg/assets/bindata.go
+++ b/operator/pkg/assets/bindata.go
@@ -111,7 +111,7 @@ func assetsCsiControllerServiceYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "assets/csi-controller-service.yaml", size: 2146, mode: os.FileMode(420), modTime: time.Unix(1620934013, 0)}
+	info := bindataFileInfo{name: "assets/csi-controller-service.yaml", size: 2146, mode: os.FileMode(420), modTime: time.Unix(1620937712, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -131,7 +131,7 @@ func assetsCsiDriverEnvYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "assets/csi-driver-env.yaml", size: 124, mode: os.FileMode(420), modTime: time.Unix(1620855950, 0)}
+	info := bindataFileInfo{name: "assets/csi-driver-env.yaml", size: 124, mode: os.FileMode(420), modTime: time.Unix(1620937712, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -151,7 +151,7 @@ func assetsCsiDriverYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "assets/csi-driver.yaml", size: 201, mode: os.FileMode(420), modTime: time.Unix(1620934013, 0)}
+	info := bindataFileInfo{name: "assets/csi-driver.yaml", size: 201, mode: os.FileMode(420), modTime: time.Unix(1620937712, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -171,7 +171,7 @@ func assetsCsiNodeServiceYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "assets/csi-node-service.yaml", size: 3330, mode: os.FileMode(420), modTime: time.Unix(1620934013, 0)}
+	info := bindataFileInfo{name: "assets/csi-node-service.yaml", size: 3330, mode: os.FileMode(420), modTime: time.Unix(1620937712, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -191,7 +191,7 @@ func assetsCsiReconcilerYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "assets/csi-reconciler.yaml", size: 1373, mode: os.FileMode(420), modTime: time.Unix(1620934013, 0)}
+	info := bindataFileInfo{name: "assets/csi-reconciler.yaml", size: 1373, mode: os.FileMode(420), modTime: time.Unix(1620937712, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -291,7 +291,7 @@ func assetsDatasetPvcYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "assets/dataset-pvc.yaml", size: 253, mode: os.FileMode(420), modTime: time.Unix(1620934013, 0)}
+	info := bindataFileInfo{name: "assets/dataset-pvc.yaml", size: 253, mode: os.FileMode(420), modTime: time.Unix(1620937712, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -491,7 +491,7 @@ func assetsStorageClassYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "assets/storage-class.yaml", size: 123, mode: os.FileMode(420), modTime: time.Unix(1620934013, 0)}
+	info := bindataFileInfo{name: "assets/storage-class.yaml", size: 123, mode: os.FileMode(420), modTime: time.Unix(1620937712, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }


### PR DESCRIPTION
### Issue Details

**Description**
Protect kube-* and openshift-* namespaces from auto mount

### Checklist

- [x] E2E tests pass
- [x] Unit tests are included
- [ ] Driver version updated (if applicable) - n/a
- [x] Operator version updated (if applicable)
- [x] Operator bundle version updated (if applicable)
- [x] DCO sign-off included

[Developer Certificate of Origin (DCO)](https://developercertificate.org/) Sign off

Signed-off-by: grishgo-dev <79328212+grishgo-dev@users.noreply.github.com>

**Note** 
All commits to `main` will publish driver, operator and operator bundle container images. To skip one or more of these, use the following indicators in the PR commit title: `skipdriver`, `skipoperator`, `skipbundle`
