### PR TITLE
fix: update kubebuilder download path (skipdriver, skipoperator, skipbundle)

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -28,7 +28,7 @@ jobs:
         os=$(go env GOOS)
         arch=$(go env GOARCH)
         # download kubebuilder and extract it to tmp
-        curl -L https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.3.1/kubebuilder_2.3.1_$(go env GOOS)_$(go env GOARCH).tar.gz | tar -xz -C /tmp/
+        curl -L https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.3.1/kubebuilder_2.3.1_${os}_${arch}.tar.gz | tar -xz -C /tmp/
         # move to a long-term location and put it on your path
         # (you'll need to set the KUBEBUILDER_ASSETS env var if you put it somewhere else)
         sudo mv /tmp/kubebuilder_2.3.1_${os}_${arch} /usr/local/kubebuilder

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -28,7 +28,7 @@ jobs:
         os=$(go env GOOS)
         arch=$(go env GOARCH)
         # download kubebuilder and extract it to tmp
-        curl -L https://go.kubebuilder.io/dl/2.3.1/${os}/${arch} | tar -xz -C /tmp/
+        curl -L https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.3.1/kubebuilder_2.3.1_$(go env GOOS)_$(go env GOARCH).tar.gz | tar -xz -C /tmp/
         # move to a long-term location and put it on your path
         # (you'll need to set the KUBEBUILDER_ASSETS env var if you put it somewhere else)
         sudo mv /tmp/kubebuilder_2.3.1_${os}_${arch} /usr/local/kubebuilder

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
         os=$(go env GOOS)
         arch=$(go env GOARCH)
         # download kubebuilder and extract it to tmp
-        curl -L https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.3.1/kubebuilder_2.3.1_$(go env GOOS)_$(go env GOARCH).tar.gz | tar -xz -C /tmp/
+        curl -L https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.3.1/kubebuilder_2.3.1_${os}_${arch}.tar.gz | tar -xz -C /tmp/
         # move to a long-term location and put it on your path
         # (you'll need to set the KUBEBUILDER_ASSETS env var if you put it somewhere else)
         sudo mv /tmp/kubebuilder_2.3.1_${os}_${arch} /usr/local/kubebuilder

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
         os=$(go env GOOS)
         arch=$(go env GOARCH)
         # download kubebuilder and extract it to tmp
-        curl -L https://go.kubebuilder.io/dl/2.3.1/${os}/${arch} | tar -xz -C /tmp/
+        curl -L https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.3.1/kubebuilder_2.3.1_$(go env GOOS)_$(go env GOARCH).tar.gz | tar -xz -C /tmp/
         # move to a long-term location and put it on your path
         # (you'll need to set the KUBEBUILDER_ASSETS env var if you put it somewhere else)
         sudo mv /tmp/kubebuilder_2.3.1_${os}_${arch} /usr/local/kubebuilder


### PR DESCRIPTION
### Issue Details
Link (if applicable): 

**Description**

### Checklist

- [ ] E2E tests pass
- [ ] Unit tests are included
- [ ] Driver version updated (if applicable)
- [ ] Operator version updated (if applicable)
- [ ] Operator bundle version updated (if applicable)
- [ ] DCO sign-off included

[Developer Certificate of Origin (DCO)](https://developercertificate.org/) Sign off

Signed-off-by: 

**Note** 
All commits to `main` will publish driver, operator and operator bundle container images. To skip one or more of these, use the following indicators in the PR commit title: `skipdriver`, `skipoperator`, `skipbundle`
